### PR TITLE
Fix color parsing for empty strings

### DIFF
--- a/src/main/java/at/bitfire/ical4android/Css3Color.kt
+++ b/src/main/java/at/bitfire/ical4android/Css3Color.kt
@@ -178,6 +178,8 @@ enum class Css3Color(val argb: Int) {
                     Color.parseColor(color)
                 } catch(e: IllegalArgumentException) {
                     null
+                } catch(e: StringIndexOutOfBoundsException) {
+                    null
                 }
 
         /**


### PR DESCRIPTION
This fixes an ICSx⁵ crash which I and some friends observed on a publicly shared Nextcloud calendar.

Stack trace of the crash (provided in-app):

```
length=0; index=0

java.lang.StringIndexOutOfBoundsException: length=0; index=0
	at java.lang.String.charAt(Native Method)
	at android.graphics.Color.parseColor(Color.java:1384)
	at at.bitfire.ical4android.Css3Color$Companion.colorFromString(Css3Color.kt:178)
	at at.bitfire.icsdroid.ui.AddCalendarValidationFragment$ValidationModel$initialize$downloader$1.onSuccess(AddCalendarValidationFragment.kt:126)
	at at.bitfire.icsdroid.CalendarFetcher.fetchNetwork$icsx5_62_2_0_2_standardRelease(CalendarFetcher.kt:155)
	at at.bitfire.icsdroid.CalendarFetcher.run(CalendarFetcher.kt:46)
	at java.lang.Thread.run(Thread.java:764)
```

The problem seems to be an empty string for the color in the ICS file:

```
BEGIN:VCALENDAR
VERSION:2.0
CALSCALE:GREGORIAN
PRODID:-//SabreDAV//SabreDAV//EN
X-WR-CALNAME:Nextcloudcalendarname (nextcloudusername)
X-APPLE-CALENDAR-COLOR:
REFRESH-INTERVAL;VALUE=DURATION:PT4H
X-PUBLISHED-TTL:PT4H
BEGIN:VTIMEZONE
TZID:Europe/Berlin
```

Disclaimer: I am not a kotlin or java programmer. Please let me know if the double catch clause is bad style, so that I can do it differently.