### PR TITLE
Handling period durations of days with `T` prefix

### DIFF
--- a/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
+++ b/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
@@ -66,7 +66,7 @@ class ICalPreprocessorTest {
     }
 
     @Test
-    fun testFixInvalidDurationTPrefixOffset() {
+    fun testFixInvalidDuration() {
         val invalid = "BEGIN:VEVENT\n" +
                 "LAST-MODIFIED:20230108T011226Z\n" +
                 "DTSTAMP:20230108T011226Z\n" +

--- a/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
+++ b/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
@@ -102,7 +102,7 @@ class ICalPreprocessorTest {
                 "CLASS:PUBLIC\n" +
                 "DESCRIPTION:Example description\n" +
                 "BEGIN:VALARM\n" +
-                "TRIGGER:-PT48H\n" +
+                "TRIGGER:-P2D\n" +
                 "ACTION:DISPLAY\n" +
                 "DESCRIPTION:Reminder\n" +
                 "END:VALARM\n" +

--- a/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
+++ b/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
@@ -13,6 +13,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.io.InputStreamReader
 import java.io.StringReader
+import java.time.Duration
 
 class ICalPreprocessorTest {
 
@@ -112,6 +113,27 @@ class ICalPreprocessorTest {
         ICalPreprocessor.fixInvalidDayOffset(StringReader(valid)).let { result ->
             assertEquals(valid, IOUtils.toString(result))
         }
+    }
+
+    @Test
+    fun testFixInvalidDuration() {
+        val original = "-PT2D"
+        val originalIsValid = try {
+            Duration.parse(original)
+            true
+        } catch (e: Exception) {
+            false
+        }
+        assertEquals(originalIsValid, false)
+
+        val fixed = ICalPreprocessor.fixInvalidDayOffset(StringReader(original))
+        val fixedIsValid = try {
+            Duration.parse(IOUtils.toString(fixed))
+            true
+        } catch (e: Exception) {
+            false
+        }
+        assertEquals(fixedIsValid, true)
     }
 
     @Test

--- a/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
+++ b/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
@@ -57,10 +57,10 @@ class ICalPreprocessorTest {
                 "TZNAME:EST" +
                 "END:STANDARD\n" +
                 "END:VTIMEZONE"
-        ICalPreprocessor.fixInvalidUtcOffset(StringReader(invalid)).let { result ->
+        ICalPreprocessor.preprocessStream(StringReader(invalid)).let { result ->
             assertEquals(valid, IOUtils.toString(result))
         }
-        ICalPreprocessor.fixInvalidUtcOffset(StringReader(valid)).let { result ->
+        ICalPreprocessor.preprocessStream(StringReader(valid)).let { result ->
             assertEquals(valid, IOUtils.toString(result))
         }
     }
@@ -107,10 +107,10 @@ class ICalPreprocessorTest {
                 "DESCRIPTION:Reminder\n" +
                 "END:VALARM\n" +
                 "END:VEVENT"
-        ICalPreprocessor.fixInvalidDayOffset(StringReader(invalid)).let { result ->
+        ICalPreprocessor.preprocessStream(StringReader(invalid)).let { result ->
             assertEquals(valid, IOUtils.toString(result))
         }
-        ICalPreprocessor.fixInvalidDayOffset(StringReader(valid)).let { result ->
+        ICalPreprocessor.preprocessStream(StringReader(valid)).let { result ->
             assertEquals(valid, IOUtils.toString(result))
         }
     }
@@ -127,7 +127,7 @@ class ICalPreprocessorTest {
         // Check that the original value cannot be parsed to a Duration
         assertEquals(originalIsValid, false)
 
-        val fixed = ICalPreprocessor.fixInvalidDayOffset(StringReader(original))
+        val fixed = ICalPreprocessor.preprocessStream(StringReader(original))
         val fixedIsValid = try {
             Duration.parse(IOUtils.toString(fixed))
             true

--- a/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
+++ b/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
@@ -65,6 +65,56 @@ class ICalPreprocessorTest {
     }
 
     @Test
+    fun testFixInvalidDurationTPrefixOffset() {
+        val invalid = "BEGIN:VEVENT\n" +
+                "LAST-MODIFIED:20230108T011226Z\n" +
+                "DTSTAMP:20230108T011226Z\n" +
+                "X-ECAL-SCHEDULE:63b0e38979739f000d5c1724\n" +
+                "DTSTART:20230101T015100Z\n" +
+                "DTEND:20230101T020600Z\n" +
+                "SUMMARY:This is a test event\n" +
+                "TRANSP:TRANSPARENT\n" +
+                "SEQUENCE:0\n" +
+                "UID:63b0e389453c5d000e1161ae\n" +
+                "PRIORITY:5\n" +
+                "X-MICROSOFT-CDO-IMPORTANCE:1\n" +
+                "CLASS:PUBLIC\n" +
+                "DESCRIPTION:Example description\n" +
+                "BEGIN:VALARM\n" +
+                "TRIGGER:-PT2D\n" +
+                "ACTION:DISPLAY\n" +
+                "DESCRIPTION:Reminder\n" +
+                "END:VALARM\n" +
+                "END:VEVENT"
+        val valid = "BEGIN:VEVENT\n" +
+                "LAST-MODIFIED:20230108T011226Z\n" +
+                "DTSTAMP:20230108T011226Z\n" +
+                "X-ECAL-SCHEDULE:63b0e38979739f000d5c1724\n" +
+                "DTSTART:20230101T015100Z\n" +
+                "DTEND:20230101T020600Z\n" +
+                "SUMMARY:This is a test event\n" +
+                "TRANSP:TRANSPARENT\n" +
+                "SEQUENCE:0\n" +
+                "UID:63b0e389453c5d000e1161ae\n" +
+                "PRIORITY:5\n" +
+                "X-MICROSOFT-CDO-IMPORTANCE:1\n" +
+                "CLASS:PUBLIC\n" +
+                "DESCRIPTION:Example description\n" +
+                "BEGIN:VALARM\n" +
+                "TRIGGER:-PT48H\n" +
+                "ACTION:DISPLAY\n" +
+                "DESCRIPTION:Reminder\n" +
+                "END:VALARM\n" +
+                "END:VEVENT"
+        ICalPreprocessor.fixInvalidDayOffset(StringReader(invalid)).let { result ->
+            assertEquals(valid, IOUtils.toString(result))
+        }
+        ICalPreprocessor.fixInvalidDayOffset(StringReader(valid)).let { result ->
+            assertEquals(valid, IOUtils.toString(result))
+        }
+    }
+
+    @Test
     fun testMsTimeZones() {
         javaClass.classLoader!!.getResourceAsStream("events/outlook1.ics").use { stream ->
             val reader = InputStreamReader(stream, Charsets.UTF_8)

--- a/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
+++ b/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
@@ -116,29 +116,6 @@ class ICalPreprocessorTest {
     }
 
     @Test
-    fun testFixInvalidDuration() {
-        val original = "-PT2D"
-        val originalIsValid = try {
-            Duration.parse(original)
-            true
-        } catch (e: Exception) {
-            false
-        }
-        // Check that the original value cannot be parsed to a Duration
-        assertEquals(originalIsValid, false)
-
-        val fixed = ICalPreprocessor.preprocessStream(StringReader(original))
-        val fixedIsValid = try {
-            Duration.parse(IOUtils.toString(fixed))
-            true
-        } catch (e: Exception) {
-            false
-        }
-        // Check that the new value is a valid Duration
-        assertEquals(fixedIsValid, true)
-    }
-
-    @Test
     fun testMsTimeZones() {
         javaClass.classLoader!!.getResourceAsStream("events/outlook1.ics").use { stream ->
             val reader = InputStreamReader(stream, Charsets.UTF_8)

--- a/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
+++ b/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
@@ -124,6 +124,7 @@ class ICalPreprocessorTest {
         } catch (e: Exception) {
             false
         }
+        // Check that the original value cannot be parsed to a Duration
         assertEquals(originalIsValid, false)
 
         val fixed = ICalPreprocessor.fixInvalidDayOffset(StringReader(original))
@@ -133,6 +134,7 @@ class ICalPreprocessorTest {
         } catch (e: Exception) {
             false
         }
+        // Check that the new value is a valid Duration
         assertEquals(fixedIsValid, true)
     }
 

--- a/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
+++ b/src/androidTest/java/at/bitfire/ical4android/ICalPreprocessorTest.kt
@@ -146,7 +146,7 @@ class ICalPreprocessorTest {
             val vEvent = calendar.getComponent(Component.VEVENT) as VEvent
 
             assertEquals("W. Europe Standard Time", vEvent.startDate.timeZone.id)
-            ICalPreprocessor.preProcess(calendar)
+            ICalPreprocessor.preprocessCalendar(calendar)
             assertEquals("Europe/Vienna", vEvent.startDate.timeZone.id)
         }
     }

--- a/src/main/java/at/bitfire/ical4android/ICalendar.kt
+++ b/src/main/java/at/bitfire/ical4android/ICalendar.kt
@@ -80,14 +80,13 @@ open class ICalendar {
             Ical4Android.log.fine("Parsing iCalendar stream")
             Ical4Android.checkThreadContextClassLoader()
 
-            // apply hacks and workarounds that operate on plain text level
-            val reader2 = ICalPreprocessor.fixInvalidUtcOffset(reader)
-            val reader3 = ICalPreprocessor.fixInvalidDayOffset(reader2)
+            // preprocess stream to work around some problems that can't be fixed later
+            val preprocessed = ICalPreprocessor.preprocessStream(reader)
 
             // parse stream
             val calendar: Calendar
             try {
-                calendar = CalendarBuilder().build(reader3)
+                calendar = CalendarBuilder().build(preprocessed)
             } catch(e: ParserException) {
                 throw InvalidCalendarException("Couldn't parse iCalendar", e)
             } catch(e: IllegalArgumentException) {
@@ -96,7 +95,7 @@ open class ICalendar {
 
             // apply ICalPreprocessor for increased compatibility
             try {
-                ICalPreprocessor.preProcess(calendar)
+                ICalPreprocessor.preprocessCalendar(calendar)
             } catch (e: Exception) {
                 Ical4Android.log.log(Level.WARNING, "Couldn't pre-process iCalendar", e)
             }

--- a/src/main/java/at/bitfire/ical4android/ICalendar.kt
+++ b/src/main/java/at/bitfire/ical4android/ICalendar.kt
@@ -82,11 +82,12 @@ open class ICalendar {
 
             // apply hacks and workarounds that operate on plain text level
             val reader2 = ICalPreprocessor.fixInvalidUtcOffset(reader)
+            val reader3 = ICalPreprocessor.fixInvalidDayOffset(reader2)
 
             // parse stream
             val calendar: Calendar
             try {
-                calendar = CalendarBuilder().build(reader2)
+                calendar = CalendarBuilder().build(reader3)
             } catch(e: ParserException) {
                 throw InvalidCalendarException("Couldn't parse iCalendar", e)
             } catch(e: IllegalArgumentException) {

--- a/src/main/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessor.kt
+++ b/src/main/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessor.kt
@@ -19,25 +19,10 @@ object FixInvalidDayOffsetPreprocessor : StreamPreprocessor() {
         var s: String = original
 
         // Find all matches for the expression
-        val found = regexpForProblem().findAll(s)
-        for (match in found) {
-            // Get the range of the match
-            val range = match.range
-            // Get the start position of the match
-            val start = range.first
-            // And the end position
-            val end = range.last
-            // Get the position of the number inside str (without the prefix)
-            val numPos = s.indexOf("PT", start) + 2
-            // And get the number, converting it to long
-            val number = s.substring(numPos, end).toLongOrNull()
-            // If the number has been converted to long correctly
-            if (number != null) {
-                // Build a new string with the prefix given, and the number converted to hours
-                val newPiece = s.substring(start, numPos) + (number * 24) + "H"
-                // Replace the range found with the new piece
-                s = s.replaceRange(IntRange(start, end), newPiece)
-            }
+        val found = regexpForProblem().find(s) ?: return s
+        for (match in found.groupValues) {
+            val fixed = match.replace("PT", "P")
+            s = s.replace(match, fixed)
         }
         return s
     }

--- a/src/main/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessor.kt
+++ b/src/main/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessor.kt
@@ -1,0 +1,47 @@
+/***************************************************************************************************
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ **************************************************************************************************/
+
+package at.bitfire.ical4android.validation
+
+/**
+ * Fixes durations with day offsets with the 'T' prefix.
+ * See also https://github.com/bitfireAT/icsx5/issues/100
+ */
+object FixInvalidDayOffsetPreprocessor: StreamPreprocessor() {
+
+    private val INVALID_DAY_PERIOD_REGEX = Regex("^(DURATION|TRIGGER):-?PT-?\\d+D$",
+        setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
+
+    override fun regexpForProblem() = INVALID_DAY_PERIOD_REGEX
+
+    override fun fixString(original: String): String {
+        var s: String = original
+
+        // FIXME I have changed the regex (added ^, DURATION|TRIGGER and $)
+
+        // Find all matches for the expression
+        val found = INVALID_DAY_PERIOD_REGEX.findAll(s)
+        for (match in found) {
+            // Get the range of the match
+            val range = match.range
+            // Get the start position of the match
+            val start = range.first
+            // And the end position
+            val end = range.last
+            // Get the position of the number inside str (without the prefix)
+            val numPos = s.indexOf("PT", start) + 2
+            // And get the number, converting it to long
+            val number = s.substring(numPos, end).toLongOrNull()
+            // If the number has been converted to long correctly
+            if (number != null) {
+                // Build a new string with the prefix given, and the number converted to hours
+                val newPiece = s.substring(start, numPos) + (number*24) + "H"
+                // Replace the range found with the new piece
+                s = s.replaceRange(IntRange(start, end), newPiece)
+            }
+        }
+        return s
+    }
+
+}

--- a/src/main/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessor.kt
+++ b/src/main/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessor.kt
@@ -12,7 +12,7 @@ object FixInvalidDayOffsetPreprocessor : StreamPreprocessor() {
 
     override fun regexpForProblem() = Regex(
         "^(DURATION|TRIGGER):-?PT-?\\d+D$",
-        setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE),
+        setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE)
     )
 
     override fun fixString(original: String): String {

--- a/src/main/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessor.kt
+++ b/src/main/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessor.kt
@@ -18,8 +18,6 @@ object FixInvalidDayOffsetPreprocessor : StreamPreprocessor() {
     override fun fixString(original: String): String {
         var s: String = original
 
-        // FIXME I have changed the regex (added ^, DURATION|TRIGGER and $)
-
         // Find all matches for the expression
         val found = regexpForProblem().findAll(s)
         for (match in found) {

--- a/src/main/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessor.kt
+++ b/src/main/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessor.kt
@@ -8,12 +8,12 @@ package at.bitfire.ical4android.validation
  * Fixes durations with day offsets with the 'T' prefix.
  * See also https://github.com/bitfireAT/icsx5/issues/100
  */
-object FixInvalidDayOffsetPreprocessor: StreamPreprocessor() {
+object FixInvalidDayOffsetPreprocessor : StreamPreprocessor() {
 
-    private val INVALID_DAY_PERIOD_REGEX = Regex("^(DURATION|TRIGGER):-?PT-?\\d+D$",
-        setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
-
-    override fun regexpForProblem() = INVALID_DAY_PERIOD_REGEX
+    override fun regexpForProblem() = Regex(
+        "^(DURATION|TRIGGER):-?PT-?\\d+D$",
+        setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE),
+    )
 
     override fun fixString(original: String): String {
         var s: String = original
@@ -21,7 +21,7 @@ object FixInvalidDayOffsetPreprocessor: StreamPreprocessor() {
         // FIXME I have changed the regex (added ^, DURATION|TRIGGER and $)
 
         // Find all matches for the expression
-        val found = INVALID_DAY_PERIOD_REGEX.findAll(s)
+        val found = regexpForProblem().findAll(s)
         for (match in found) {
             // Get the range of the match
             val range = match.range
@@ -36,7 +36,7 @@ object FixInvalidDayOffsetPreprocessor: StreamPreprocessor() {
             // If the number has been converted to long correctly
             if (number != null) {
                 // Build a new string with the prefix given, and the number converted to hours
-                val newPiece = s.substring(start, numPos) + (number*24) + "H"
+                val newPiece = s.substring(start, numPos) + (number * 24) + "H"
                 // Replace the range found with the new piece
                 s = s.replaceRange(IntRange(start, end), newPiece)
             }

--- a/src/main/java/at/bitfire/ical4android/validation/FixInvalidUtcOffsetPreprocessor.kt
+++ b/src/main/java/at/bitfire/ical4android/validation/FixInvalidUtcOffsetPreprocessor.kt
@@ -1,0 +1,31 @@
+/***************************************************************************************************
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ **************************************************************************************************/
+
+package at.bitfire.ical4android.validation
+
+import at.bitfire.ical4android.Ical4Android
+import at.bitfire.ical4android.validation.FixInvalidUtcOffsetPreprocessor.TZOFFSET_REGEXP
+import java.util.logging.Level
+
+
+/**
+ * Some servers modify UTC offsets in TZOFFSET(FROM,TO) like "+005730" to an invalid "+5730".
+ *
+ * Rewrites values of all TZOFFSETFROM and TZOFFSETTO properties which match [TZOFFSET_REGEXP]
+ * so that an hour value of 00 is inserted.
+ */
+object FixInvalidUtcOffsetPreprocessor: StreamPreprocessor() {
+
+    private val TZOFFSET_REGEXP = Regex("^(TZOFFSET(FROM|TO):[+\\-]?)((18|19|[2-6]\\d)\\d\\d)$",
+        setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
+
+    override fun regexpForProblem() = TZOFFSET_REGEXP
+
+    override fun fixString(original: String) =
+        original.replace(TZOFFSET_REGEXP) {
+            Ical4Android.log.log(Level.FINE, "Applying Synology WebDAV fix to invalid utc-offset", it.value)
+            "${it.groupValues[1]}00${it.groupValues[3]}"
+        }
+
+}

--- a/src/main/java/at/bitfire/ical4android/validation/ICalPreprocessor.kt
+++ b/src/main/java/at/bitfire/ical4android/validation/ICalPreprocessor.kt
@@ -33,8 +33,8 @@ object ICalPreprocessor {
     )
 
     val streamPreprocessors = arrayOf(
-        FixInvalidUtcOffsetPreprocessor,
-        FixInvalidDayOffsetPreprocessor
+        FixInvalidUtcOffsetPreprocessor,    // fix things like TZOFFSET(FROM,TO):+5730
+        FixInvalidDayOffsetPreprocessor     // fix things like DURATION:PT2D
     )
 
     /**
@@ -66,14 +66,14 @@ object ICalPreprocessor {
     @Suppress("UNCHECKED_CAST")
     private fun applyRules(property: Property) {
         propertyRules
-                .filter { rule -> rule.supportedType.isAssignableFrom(property::class.java) }
-                .forEach {
-                    val beforeStr = property.toString()
-                    (it as Rfc5545PropertyRule<Property>).applyTo(property)
-                    val afterStr = property.toString()
-                    if (beforeStr != afterStr)
-                        Ical4Android.log.log(Level.FINER, "$beforeStr -> $afterStr")
-                }
+            .filter { rule -> rule.supportedType.isAssignableFrom(property::class.java) }
+            .forEach {
+                val beforeStr = property.toString()
+                (it as Rfc5545PropertyRule<Property>).applyTo(property)
+                val afterStr = property.toString()
+                if (beforeStr != afterStr)
+                    Ical4Android.log.log(Level.FINER, "$beforeStr -> $afterStr")
+            }
     }
 
 }

--- a/src/main/java/at/bitfire/ical4android/validation/ICalPreprocessor.kt
+++ b/src/main/java/at/bitfire/ical4android/validation/ICalPreprocessor.kt
@@ -11,10 +11,7 @@ import net.fortuna.ical4j.transform.rfc5545.CreatedPropertyRule
 import net.fortuna.ical4j.transform.rfc5545.DateListPropertyRule
 import net.fortuna.ical4j.transform.rfc5545.DatePropertyRule
 import net.fortuna.ical4j.transform.rfc5545.Rfc5545PropertyRule
-import org.apache.commons.io.IOUtils
-import java.io.IOException
 import java.io.Reader
-import java.io.StringReader
 import java.util.*
 import java.util.logging.Level
 
@@ -28,10 +25,6 @@ import java.util.logging.Level
  */
 object ICalPreprocessor {
 
-    private val TZOFFSET_REGEXP = Regex("^(TZOFFSET(FROM|TO):[+\\-]?)((18|19|[2-6]\\d)\\d\\d)$", RegexOption.MULTILINE)
-
-    private val INVALID_DAY_PERIOD_REGEX = Regex("-?PT-?\\d+D", setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
-
     private val propertyRules = arrayOf(
         CreatedPropertyRule(),      // make sure CREATED is UTC
 
@@ -39,108 +32,22 @@ object ICalPreprocessor {
         DateListPropertyRule(),     // ... by the ical4j VTIMEZONE with the same TZID!
     )
 
+    val streamPreprocessors = arrayOf(
+        FixInvalidUtcOffsetPreprocessor,
+        FixInvalidDayOffsetPreprocessor
+    )
 
     /**
-     * Some servers modify UTC offsets in TZOFFSET(FROM,TO) like "+005730" to an invalid "+5730".
+     * Applies [streamPreprocessors] to a given [Reader] that reads an iCalendar object
+     * in order to repair some things that must be fixed before parsing.
      *
-     * Rewrites values of all TZOFFSETFROM and TZOFFSETTO properties which match [TZOFFSET_REGEXP]
-     * so that an hour value of 00 is inserted.
-     *
-     * @param reader Reader that reads the potentially broken iCalendar (which for instance contains `TZOFFSETFROM:+5730`)
-     * @return Reader that reads the fixed iCalendar (for instance `TZOFFSETFROM:+005730`)
+     * @param original    original iCalendar object
+     * @return            the potentially repaired iCalendar object
      */
-    fun fixInvalidUtcOffset(reader: Reader): Reader {
-        fun fixStringFromReader() =
-                IOUtils.toString(reader).replace(TZOFFSET_REGEXP) {
-                    Ical4Android.log.log(Level.FINE, "Applying Synology WebDAV fix to invalid utc-offset", it.value)
-                    "${it.groupValues[1]}00${it.groupValues[3]}"
-                }
-
-        var result: String? = null
-
-        val resetSupported = try {
-            reader.reset()
-            true
-        } catch(e: IOException) {
-            false
-        }
-
-        if (resetSupported) {
-            // reset is supported, no need to copy the whole stream to another String (unless we have to fix the TZOFFSET)
-            if (Scanner(reader).findWithinHorizon(TZOFFSET_REGEXP.toPattern(), 0) != null) {
-                reader.reset()
-                result = fixStringFromReader()
-            }
-        } else
-            result = fixStringFromReader()
-
-        if (result != null)
-            return StringReader(result)
-
-        // not modified, return original iCalendar
-        reader.reset()
-        return reader
-    }
-
-    /**
-     * Fixes durations with day offsets with the 'T' prefix.
-     * @param reader Reader that reads the potentially broken iCalendar
-     * @see <a href="https://github.com/bitfireAT/icsx5/issues/100">GitHub</a>
-     */
-    fun fixInvalidDayOffset(reader: Reader): Reader {
-        fun fixStringFromReader(): String {
-            // Convert the reader to a string
-            var str = IOUtils.toString(reader)
-            val found = INVALID_DAY_PERIOD_REGEX.findAll(str)
-            // Find all matches for the expression
-            for (match in found) {
-                // Get the range of the match
-                val range = match.range
-                // Get the start position of the match
-                val start = range.first
-                // And the end position
-                val end = range.last
-                // Get the position of the number inside str (without the prefix)
-                val numPos = str.indexOf("PT", start) + 2
-                // And get the number, converting it to long
-                val number = str.substring(numPos, end).toLongOrNull()
-                // If the number has been converted to long correctly
-                if (number != null) {
-                    // Build a new string with the prefix given, and the number converted to hours
-                    val newPiece = str.substring(start, numPos) + (number*24) + "H"
-                    // Replace the range found with the new piece
-                    str = str.replaceRange(IntRange(start, end), newPiece)
-                }
-            }
-            return str
-        }
-
-        var result: String? = null
-
-        val resetSupported = try {
-            reader.reset()
-            true
-        } catch (e: IOException) {
-            false
-        }
-
-        if (resetSupported) {
-            // reset is supported, no need to copy the whole stream to another String (unless we have to fix the period)
-            val horizonFind = Scanner(reader)
-                .findWithinHorizon(INVALID_DAY_PERIOD_REGEX.toPattern(), 0)
-            if (horizonFind != null) {
-                reader.reset()
-                result = fixStringFromReader()
-            }
-        } else
-        // If reset is not supported, always try to fix the issue by copying the string
-            result = fixStringFromReader()
-
-        if (result != null)
-            return StringReader(result)
-
-        // not modified, return original iCalendar
-        reader.reset()
+    fun preprocessStream(original: Reader): Reader {
+        var reader = original
+        for (preprocessor in streamPreprocessors)
+            reader = preprocessor.preprocess(reader)
         return reader
     }
 
@@ -150,11 +57,10 @@ object ICalPreprocessor {
      *
      * @param calendar the calendar object that is going to be modified
      */
-    fun preProcess(calendar: Calendar) {
-        for (component in calendar.components) {
+    fun preprocessCalendar(calendar: Calendar) {
+        for (component in calendar.components)
             for (property in component.properties)
                 applyRules(property)
-        }
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/main/java/at/bitfire/ical4android/validation/StreamPreprocessor.kt
+++ b/src/main/java/at/bitfire/ical4android/validation/StreamPreprocessor.kt
@@ -1,0 +1,49 @@
+/***************************************************************************************************
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ **************************************************************************************************/
+
+package at.bitfire.ical4android.validation
+
+import org.apache.commons.io.IOUtils
+import java.io.IOException
+import java.io.Reader
+import java.io.StringReader
+import java.util.*
+
+abstract class StreamPreprocessor {
+
+    abstract fun regexpForProblem(): Regex?
+
+    abstract fun fixString(original: String): String
+
+    fun preprocess(reader: Reader): Reader {
+        var result: String? = null
+
+        val resetSupported = try {
+            reader.reset()
+            true
+        } catch(e: IOException) {
+            false
+        }
+
+        if (resetSupported) {
+            val regex = regexpForProblem()
+            // reset is supported, no need to copy the whole stream to another String (unless we have to fix the TZOFFSET)
+            if (regex == null || Scanner(reader).findWithinHorizon(regex.toPattern(), 0) != null) {
+                reader.reset()
+                result = fixString(IOUtils.toString(reader))
+            }
+        } else
+            // reset not supported, always generate a new String that will be returned
+            result = fixString(IOUtils.toString(reader))
+
+        if (result != null)
+            // modified or reset not supported, return new stream
+            return StringReader(result)
+
+        // not modified, return original iCalendar
+        reader.reset()
+        return reader
+    }
+
+}

--- a/src/test/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessorTest.kt
+++ b/src/test/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessorTest.kt
@@ -1,0 +1,58 @@
+/***************************************************************************************************
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ **************************************************************************************************/
+
+package at.bitfire.ical4android.validation
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class FixInvalidDayOffsetPreprocessorTest {
+
+    @Test
+    fun test_FixString_NoOccurrence() {
+        assertEquals(
+            "Some String",
+            FixInvalidDayOffsetPreprocessor.fixString("Some String"),
+        )
+    }
+
+    @Test
+    fun test_FixString_TzOffsetFrom_Invalid() {
+        assertEquals(
+            "DURATION:-PT24H",
+            FixInvalidDayOffsetPreprocessor.fixString("DURATION:-PT1D"),
+        )
+        assertEquals(
+            "TRIGGER:-PT48H",
+            FixInvalidDayOffsetPreprocessor.fixString("TRIGGER:-PT2D"),
+        )
+    }
+
+    @Test
+    fun test_FixString_TzOffsetFrom_Valid() {
+        assertEquals(
+            "DURATION:-PT12H",
+            FixInvalidDayOffsetPreprocessor.fixString("DURATION:-PT12H"),
+        )
+        assertEquals(
+            "TRIGGER:-PT12H",
+            FixInvalidDayOffsetPreprocessor.fixString("TRIGGER:-PT12H"),
+        )
+    }
+
+    @Test
+    fun test_RegexpForProblem_TzOffsetTo_Invalid() {
+        val regex = FixInvalidDayOffsetPreprocessor.regexpForProblem()
+        assertTrue(regex.matches("DURATION:PT2D"))
+        assertTrue(regex.matches("TRIGGER:PT1D"))
+    }
+
+    @Test
+    fun test_RegexpForProblem_TzOffsetTo_Valid() {
+        val regex = FixInvalidDayOffsetPreprocessor.regexpForProblem()
+        assertFalse(regex.matches("DURATION:-PT12H"))
+        assertFalse(regex.matches("TRIGGER:-PT15M"))
+    }
+
+}

--- a/src/test/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessorTest.kt
+++ b/src/test/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessorTest.kt
@@ -18,7 +18,7 @@ class FixInvalidDayOffsetPreprocessorTest {
     }
 
     @Test
-    fun test_FixString_TzOffsetFrom_Invalid() {
+    fun test_FixString_DayOffsetFrom_Invalid() {
         assertEquals(
             "DURATION:-PT24H",
             FixInvalidDayOffsetPreprocessor.fixString("DURATION:-PT1D"),
@@ -30,7 +30,7 @@ class FixInvalidDayOffsetPreprocessorTest {
     }
 
     @Test
-    fun test_FixString_TzOffsetFrom_Valid() {
+    fun test_FixString_DayOffsetFrom_Valid() {
         assertEquals(
             "DURATION:-PT12H",
             FixInvalidDayOffsetPreprocessor.fixString("DURATION:-PT12H"),
@@ -42,14 +42,14 @@ class FixInvalidDayOffsetPreprocessorTest {
     }
 
     @Test
-    fun test_RegexpForProblem_TzOffsetTo_Invalid() {
+    fun test_RegexpForProblem_DayOffsetTo_Invalid() {
         val regex = FixInvalidDayOffsetPreprocessor.regexpForProblem()
         assertTrue(regex.matches("DURATION:PT2D"))
         assertTrue(regex.matches("TRIGGER:PT1D"))
     }
 
     @Test
-    fun test_RegexpForProblem_TzOffsetTo_Valid() {
+    fun test_RegexpForProblem_DayOffsetTo_Valid() {
         val regex = FixInvalidDayOffsetPreprocessor.regexpForProblem()
         assertFalse(regex.matches("DURATION:-PT12H"))
         assertFalse(regex.matches("TRIGGER:-PT15M"))

--- a/src/test/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessorTest.kt
+++ b/src/test/java/at/bitfire/ical4android/validation/FixInvalidDayOffsetPreprocessorTest.kt
@@ -20,11 +20,11 @@ class FixInvalidDayOffsetPreprocessorTest {
     @Test
     fun test_FixString_DayOffsetFrom_Invalid() {
         assertEquals(
-            "DURATION:-PT24H",
+            "DURATION:-P1D",
             FixInvalidDayOffsetPreprocessor.fixString("DURATION:-PT1D"),
         )
         assertEquals(
-            "TRIGGER:-PT48H",
+            "TRIGGER:-P2D",
             FixInvalidDayOffsetPreprocessor.fixString("TRIGGER:-PT2D"),
         )
     }

--- a/src/test/java/at/bitfire/ical4android/validation/FixInvalidUtcOffsetPreprocessorTest.kt
+++ b/src/test/java/at/bitfire/ical4android/validation/FixInvalidUtcOffsetPreprocessorTest.kt
@@ -1,0 +1,56 @@
+/***************************************************************************************************
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ **************************************************************************************************/
+
+package at.bitfire.ical4android.validation
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class FixInvalidUtcOffsetPreprocessorTest {
+
+    @Test
+    fun test_FixString_NoOccurrence() {
+        assertEquals(
+            "Some String",
+            FixInvalidUtcOffsetPreprocessor.fixString("Some String"))
+    }
+
+    @Test
+    fun test_FixString_TzOffsetFrom_Invalid() {
+        assertEquals("TZOFFSETFROM:+005730",
+            FixInvalidUtcOffsetPreprocessor.fixString("TZOFFSETFROM:+5730"))
+    }
+
+    @Test
+    fun test_FixString_TzOffsetFrom_Valid() {
+        assertEquals("TZOFFSETFROM:+005730",
+            FixInvalidUtcOffsetPreprocessor.fixString("TZOFFSETFROM:+005730"))
+    }
+
+    @Test
+    fun test_FixString_TzOffsetTo_Invalid() {
+        assertEquals("TZOFFSETTO:+005730",
+            FixInvalidUtcOffsetPreprocessor.fixString("TZOFFSETTO:+5730"))
+    }
+
+    @Test
+    fun test_FixString_TzOffsetTo_Valid() {
+        assertEquals("TZOFFSETTO:+005730",
+            FixInvalidUtcOffsetPreprocessor.fixString("TZOFFSETTO:+005730"))
+    }
+
+
+    @Test
+    fun test_RegexpForProblem_TzOffsetTo_Invalid() {
+        val regex = FixInvalidUtcOffsetPreprocessor.regexpForProblem()
+        assertTrue(regex.matches("TZOFFSETTO:+5730"))
+    }
+
+    @Test
+    fun test_RegexpForProblem_TzOffsetTo_Valid() {
+        val regex = FixInvalidUtcOffsetPreprocessor.regexpForProblem()
+        assertFalse(regex.matches("TZOFFSETTO:+005730"))
+    }
+
+}


### PR DESCRIPTION
Context is in [icsx5#100](https://github.com/bitfireAT/ical4android/issues/77).

# Changes
* Added a new function `fixInvalidDayOffset`
* Added tests for `fixInvalidDayOffset` -> `testFixInvalidDurationTPrefixOffset`
* Added tests for parsing `Duration`s with `fixInvalidDayOffset` -> `testFixInvalidDuration`

# `fixInvalidDayOffset`
The logic for doing the replacements is:
1. Searches for all the matches in the string of the Regexp `-?PT-?\d+D`, this is all the matches that start optionally with a `-`, followed by `PT`, then optionally a `-` (this is because the negative indicator can be before `PT` or in the number properly), followed by a number, and the letter `D`.
2. Iterates for each match.
    1. Get the starting and end positions of the match.
    2. Search the position of the offset number in the string.
    3. Convert that number to a long.
    4. Multiply it by 24.
    5. Replace the found match by the prefix given (can be `PT` or `-PT`) followed by the amount of hours found, and then `H`.

# Extra considerations
Right now all matches of the "PT pattern" are replaced. This might cause issues with descriptions or other fields that for any reason have that format. Maybe we should list all the properties that have the [Duration](https://www.kanzaki.com/docs/ical/duration-t.html) type, which as far as I'm concerned are:
* [`DURATION`](https://www.kanzaki.com/docs/ical/duration.html)
* [`TRIGGER`](https://www.kanzaki.com/docs/ical/trigger.html)