### PR TITLE
Add owner display name to jtx contract

### DIFF
--- a/src/main/java/at/techbee/jtx/JtxContract.kt
+++ b/src/main/java/at/techbee/jtx/JtxContract.kt
@@ -1119,10 +1119,16 @@ object JtxContract {
         const val DESCRIPTION = "description"
 
         /**
-         * Purpose:  This column/property defines the owner of the collection.
+         * Purpose:  This column/property defines the owner url of the collection.
          * Type: [String]
          */
         const val OWNER = "owner"
+
+        /**
+         * Purpose:  This column/property defines the display name of the owner of the collection.
+         * Type: [String]
+         */
+        const val OWNER_DISPLAYNAME = "ownerDisplayname"
 
         /**
          * Purpose:  This column/property defines the color of the collection items.


### PR DESCRIPTION
This is to provide the owner display name in a jtx collection.
Reference to davx5 issue: https://github.com/bitfireAT/davx5/issues/219
Reference to davx5 branch: https://github.com/bitfireAT/davx5/tree/219-provide-owner-for-task-providers-again