### PR TITLE
recurrenceSetsToAndroidString: correctly assemble ZonedDateTime from …

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/util/AndroidTimeUtilsTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/util/AndroidTimeUtilsTest.kt
@@ -341,6 +341,16 @@ class AndroidTimeUtilsTest {
     }
 
     @Test
+    fun testRecurrenceSetsToAndroidString_Date_AlthoughDtStartIsDateTime_MonthWithLessDays() {
+        // DATEs (without time) have to be converted to <date>THHmmssZ for Android
+        val list = ArrayList<DateListProperty>(1)
+        list.add(ExDate(DateList("20240531", Value.DATE, tzDefault)))
+        val androidTimeString = AndroidTimeUtils.recurrenceSetsToAndroidString(list, DateTime("20240401T114500", tzBerlin))
+        // We ignore the timezone
+        assertEquals("20240531T094500Z", androidTimeString.substringAfter(';'))
+    }
+
+    @Test
     fun testRecurrenceSetsToAndroidString_Period() {
         // PERIODs are not supported yet — should be implemented later
         val list = listOf(

--- a/lib/src/main/kotlin/at/bitfire/ical4android/util/AndroidTimeUtils.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/util/AndroidTimeUtils.kt
@@ -24,6 +24,7 @@ import java.text.SimpleDateFormat
 import java.time.Duration
 import java.time.Period
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.TemporalAmount
 import java.util.*
@@ -192,11 +193,11 @@ object AndroidTimeUtils {
                             // take time (including time zone) from dtStart and date from date
                             val dtStartTime = (dtStart as DateTime).toZonedDateTime()
                             val localDate = date.toLocalDate()
-                            val dtStartTimeUtc = dtStartTime
-                                .withDayOfMonth(localDate.dayOfMonth)
-                                .withMonth(localDate.monthValue)
-                                .withYear(localDate.year)
-                                .withZoneSameInstant(ZoneOffset.UTC)
+                            val dtStartTimeUtc = ZonedDateTime.of(
+                                localDate,
+                                dtStartTime.toLocalTime(),
+                                dtStartTime.zone
+                            ).withZoneSameInstant(ZoneOffset.UTC)
 
                             val dateFormatUtc = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.ROOT)
                             dtStartTimeUtc.format(dateFormatUtc)


### PR DESCRIPTION
…LocalDate and LocalTime instead of modifying the original value on the fly