### PR TITLE
Upgrade ical4j to 3.2.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@
 # Files for the Dalvik VM
 *.dex
 
-# Java class files
+# Java/Kotlin files
 *.class
+.kotlin/
 
 # Generated files
 bin/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ commons-lang = "3.8.1"
 # noinspection GradleDependency
 commons-io = "2.6"
 dokka  ="1.9.10"
-ical4j = "3.2.17"
+ical4j = "3.2.18"
 junit = "4.13.2"
 kotlin = "1.9.23"
 mockk = "1.13.10"

--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/EventTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/EventTest.kt
@@ -259,7 +259,7 @@ class EventTest {
     fun testWrite() {
         val e = Event()
         e.uid = "SAMPLEUID"
-        e.dtStart = DtStart("20190101T100000", TimeZoneRegistryFactory.getInstance().createRegistry().getTimeZone("Europe/Berlin"))
+        e.dtStart = DtStart("20190101T100000", DateUtils.ical4jTimeZone("Europe/Berlin"))
         e.alarms += VAlarm(Duration.ofHours(-1))
 
         val os = ByteArrayOutputStream()

--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/ICalendarTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/ICalendarTest.kt
@@ -111,8 +111,8 @@ class ICalendarTest {
 		ICalendar.minifyVTimeZone(vtzVienna, Date("20200101")).let { minified ->
 			assertEquals(2, minified.observances.size)
 			// now earliest observance for DAYLIGHT/STANDARD is 1981/1996
-			assertEquals(DateTime("19810329T020000"), minified.observances[0].startDate.date)
-			assertEquals(DateTime("19961027T030000"), minified.observances[1].startDate.date)
+			assertEquals(DateTime("19961027T030000"), minified.observances[0].startDate.date)
+			assertEquals(DateTime("19810329T020000"), minified.observances[1].startDate.date)
 		}
 
 	}
@@ -132,8 +132,8 @@ class ICalendarTest {
 		// Keep future observances.
 		ICalendar.minifyVTimeZone(vtzVienna, Date("19751001")).let { minified ->
 			assertEquals(4, minified.observances.size)
-			assertEquals(DateTime("19160430T230000"), minified.observances[2].startDate.date)
-			assertEquals(DateTime("19161001T010000"), minified.observances[3].startDate.date)
+			assertEquals(DateTime("19161001T010000"), minified.observances[2].startDate.date)
+			assertEquals(DateTime("19160430T230000"), minified.observances[3].startDate.date)
 		}
 		ICalendar.minifyVTimeZone(vtzKarachi, Date("19611001")).let { minified ->
 			assertEquals(4, minified.observances.size)

--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/TaskTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/TaskTest.kt
@@ -198,7 +198,7 @@ class TaskTest {
     fun testWrite() {
         val t = Task()
         t.uid = "SAMPLEUID"
-        t.dtStart = DtStart("20190101T100000", TimeZoneRegistryFactory.getInstance().createRegistry().getTimeZone("Europe/Berlin"))
+        t.dtStart = DtStart("20190101T100000", DateUtils.ical4jTimeZone("Europe/Berlin"))
 
         val alarm = VAlarm(java.time.Duration.ofHours(-1) /*Dur(0, -1, 0, 0)*/)
         alarm.properties += Action.AUDIO

--- a/lib/src/main/kotlin/at/bitfire/ical4android/Event.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/Event.kt
@@ -331,7 +331,7 @@ class Event : ICalendar() {
 
         lastModified?.let { props += it }
 
-        event.alarms.addAll(alarms)
+        event.components.addAll(alarms)
 
         return event
     }

--- a/lib/src/main/kotlin/at/bitfire/ical4android/Task.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/Task.kt
@@ -257,7 +257,7 @@ class Task: ICalendar() {
         percentComplete?.let { props += PercentComplete(it) }
 
         if (alarms.isNotEmpty())
-            vTodo.alarms.addAll(alarms)
+            vTodo.components.addAll(alarms)
 
         // determine earliest referenced date
         val earliest = arrayOf(


### PR DESCRIPTION
Solves https://github.com/bitfireAT/davx5/issues/551

ical4j 3.2.18 changes its behavior so that classes like `VEvent` and `VTimeZone` now have a (read/write) `components` list, and for instance `alarms() = components.onlyAlarms()` which now don't change the underlying `components` anymore (although they're technically still mutable lists).

`VTimeZone` now doesn't allow to edit its observances anymore, so we construct a new one instead of modifying a copy of the existing one in `minifyTimeZone`.