### PR TITLE
Expect boolean instead of integer in tests

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidCalendarTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidCalendarTest.kt
@@ -23,6 +23,7 @@ import net.fortuna.ical4j.model.property.DtStart
 import org.junit.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 
 class AndroidCalendarTest {
 
@@ -77,7 +78,7 @@ class AndroidCalendarTest {
         assertNotNull(calendar)
 
         // delete calendar
-        assertEquals(1, calendar.delete())
+        assertTrue(calendar.delete())
     }
 
 

--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/DmfsTaskListTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/DmfsTaskListTest.kt
@@ -56,7 +56,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
             assertEquals(testAccount.name, taskList.tasksSyncUri().getQueryParameter(TaskContract.ACCOUNT_NAME))
         } finally {
             // delete task list
-            assertEquals(1, taskList.delete())
+            assertTrue(taskList.delete())
         }
     }
 


### PR DESCRIPTION
Tests are failing since https://github.com/bitfireAT/ical4android/commit/86af14d6c833263761903c13b50f21d548a12a8f  because tests still expected `1` as return value for a successfully deleted row. Now they expect `true` for any number of deleted rows instead.