### PR TITLE
Take ContentProviderClient instead of TasksProvider

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/DmfsTaskListTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/DmfsTaskListTest.kt
@@ -37,7 +37,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
         val uri = DmfsTaskList.create(testAccount, provider.client, providerName, info)
         assertNotNull(uri)
 
-        return DmfsTaskList.findByID(testAccount, provider, TestTaskList.Factory, ContentUris.parseId(uri))
+        return DmfsTaskList.findByID(testAccount, provider.client, providerName, TestTaskList.Factory, ContentUris.parseId(uri))
     }
 
 

--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/DmfsTaskListTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/DmfsTaskListTest.kt
@@ -21,7 +21,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
-        AbstractTasksTest(providerName) {
+    AbstractTasksTest(providerName) {
 
     private val testAccount = Account("AndroidTaskListTest", TaskContract.LOCAL_ACCOUNT_TYPE)
 
@@ -34,7 +34,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
         info.put(TaskContract.TaskLists.SYNC_ENABLED, 1)
         info.put(TaskContract.TaskLists.VISIBLE, 1)
 
-        val uri = DmfsTaskList.create(testAccount, provider, info)
+        val uri = DmfsTaskList.create(testAccount, provider.client, providerName, info)
         assertNotNull(uri)
 
         return DmfsTaskList.findByID(testAccount, provider, TestTaskList.Factory, ContentUris.parseId(uri))

--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/DmfsTaskListTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/DmfsTaskListTest.kt
@@ -80,7 +80,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
             val parentId = ContentUris.parseId(parentContentUri)
 
             // OpenTasks should provide the correct relation
-            taskList.provider.client.query(taskList.tasksPropertiesSyncUri(), null,
+            taskList.provider.query(taskList.tasksPropertiesSyncUri(), null,
                     "${Properties.TASK_ID}=?", arrayOf(childId.toString()),
                     null, null)!!.use { cursor ->
                 assertEquals(1, cursor.count)
@@ -99,7 +99,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
             taskList.touchRelations()
 
             // now parent_id should bet set
-            taskList.provider.client.query(childContentUri, arrayOf(Tasks.PARENT_ID),
+            taskList.provider.query(childContentUri, arrayOf(Tasks.PARENT_ID),
                     null, null, null)!!.use { cursor ->
                 assertTrue(cursor.moveToNext())
                 assertEquals(parentId, cursor.getLong(0))

--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/impl/TestTaskList.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/impl/TestTaskList.kt
@@ -22,13 +22,16 @@ class TestTaskList(
 
     companion object {
 
-        fun create(account: Account, provider: TaskProvider): TestTaskList {
+        fun create(
+            account: Account,
+            provider: TaskProvider,
+        ): TestTaskList {
             val values = ContentValues(4)
             values.put(TaskContract.TaskListColumns.LIST_NAME, "Test Task List")
             values.put(TaskContract.TaskListColumns.LIST_COLOR, 0xffff0000)
             values.put(TaskContract.TaskListColumns.SYNC_ENABLED, 1)
             values.put(TaskContract.TaskListColumns.VISIBLE, 1)
-            val uri = DmfsTaskList.create(account, provider, values)
+            val uri = DmfsTaskList.create(account, provider.client, provider.name, values)
 
             return TestTaskList(account, provider.client, provider.name, ContentUris.parseId(uri))
         }

--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/impl/TestTaskList.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/impl/TestTaskList.kt
@@ -5,6 +5,7 @@
 package at.bitfire.ical4android.impl
 
 import android.accounts.Account
+import android.content.ContentProviderClient
 import android.content.ContentUris
 import android.content.ContentValues
 import at.bitfire.ical4android.DmfsTaskList
@@ -14,9 +15,10 @@ import org.dmfs.tasks.contract.TaskContract
 
 class TestTaskList(
         account: Account,
-        provider: TaskProvider,
+        provider: ContentProviderClient,
+        providerName: TaskProvider.ProviderName,
         id: Long
-): DmfsTaskList<TestTask>(account, provider, TestTask.Factory, id) {
+): DmfsTaskList<TestTask>(account, provider, providerName, TestTask.Factory, id) {
 
     companion object {
 
@@ -28,15 +30,15 @@ class TestTaskList(
             values.put(TaskContract.TaskListColumns.VISIBLE, 1)
             val uri = DmfsTaskList.create(account, provider, values)
 
-            return TestTaskList(account, provider, ContentUris.parseId(uri))
+            return TestTaskList(account, provider.client, provider.name, ContentUris.parseId(uri))
         }
 
     }
 
 
     object Factory: DmfsTaskListFactory<TestTaskList> {
-        override fun newInstance(account: Account, provider: TaskProvider, id: Long) =
-                TestTaskList(account, provider, id)
+        override fun newInstance(account: Account, provider: ContentProviderClient, providerName: TaskProvider.ProviderName, id: Long) =
+                TestTaskList(account, provider, providerName, id)
     }
 
 }

--- a/lib/src/main/kotlin/at/bitfire/ical4android/DmfsTask.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/DmfsTask.kt
@@ -99,7 +99,7 @@ abstract class DmfsTask(
             val id = requireNotNull(id)
 
             try {
-                val client = taskList.provider.client
+                val client = taskList.provider
                 client.query(taskSyncURI(true), null, null, null, null)?.use { cursor ->
                     if (cursor.moveToFirst()) {
                         // create new Task which will be populated
@@ -161,7 +161,7 @@ abstract class DmfsTask(
         task.sequence = values.getAsInteger(Tasks.SYNC_VERSION)
         task.summary = values.getAsString(Tasks.TITLE)
         task.location = values.getAsString(Tasks.LOCATION)
-        task.userAgents += taskList.provider.name.packageName
+        task.userAgents += taskList.providerName.packageName
 
         values.getAsString(Tasks.GEO)?.let { geo ->
             val (lng, lat) = geo.split(',')
@@ -330,7 +330,7 @@ abstract class DmfsTask(
 
 
     fun add(): Uri {
-        val batch = BatchOperation(taskList.provider.client)
+        val batch = BatchOperation(taskList.provider)
 
         val builder = CpoBuilder.newInsert(taskList.tasksSyncUri())
         buildTask(builder, false)
@@ -350,7 +350,7 @@ abstract class DmfsTask(
         this.task = task
         val existingId = requireNotNull(id)
 
-        val batch = BatchOperation(taskList.provider.client)
+        val batch = BatchOperation(taskList.provider)
 
         // remove associated rows which are added later again
         batch.enqueue(CpoBuilder
@@ -367,7 +367,7 @@ abstract class DmfsTask(
         insertProperties(batch, null)
 
         batch.commit()
-        return ContentUris.withAppendedId(taskList.provider.tasksUri(), existingId)
+        return ContentUris.withAppendedId(Tasks.getContentUri(taskList.providerName.authority), existingId)
     }
 
     protected open fun insertProperties(batch: BatchOperation, idxTask: Int?) {
@@ -472,7 +472,7 @@ abstract class DmfsTask(
     }
 
     fun delete(): Int {
-        return taskList.provider.client.delete(taskSyncURI(), null, null)
+        return taskList.provider.delete(taskSyncURI(), null, null)
     }
 
     @CallSuper

--- a/lib/src/main/kotlin/at/bitfire/ical4android/DmfsTaskList.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/DmfsTaskList.kt
@@ -51,19 +51,20 @@ abstract class DmfsTaskList<out T : DmfsTask>(
 
         fun <T : DmfsTaskList<DmfsTask>> findByID(
             account: Account,
-            provider: TaskProvider,
+            provider: ContentProviderClient,
+            providerName: TaskProvider.ProviderName,
             factory: DmfsTaskListFactory<T>,
             id: Long
         ): T {
-            provider.client.query(
-                ContentUris.withAppendedId(provider.taskListsUri(), id).asSyncAdapter(account),
+            provider.query(
+                ContentUris.withAppendedId(TaskLists.getContentUri(providerName.authority), id).asSyncAdapter(account),
                 null,
                 null,
                 null,
                 null
             )?.use { cursor ->
                 if (cursor.moveToNext()) {
-                    val taskList = factory.newInstance(account, provider.client, provider.name, id)
+                    val taskList = factory.newInstance(account, provider, providerName, id)
                     taskList.populate(cursor.toValues())
                     return taskList
                 }

--- a/lib/src/main/kotlin/at/bitfire/ical4android/DmfsTaskList.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/DmfsTaskList.kt
@@ -39,12 +39,13 @@ abstract class DmfsTaskList<out T : DmfsTask>(
         private val logger
             get() = Logger.getLogger(DmfsTaskList::class.java.name)
 
-        fun create(account: Account, provider: TaskProvider, info: ContentValues): Uri {
+        fun create(account: Account, provider: ContentProviderClient, providerName: TaskProvider.ProviderName, info: ContentValues): Uri {
             info.put(TaskContract.ACCOUNT_NAME, account.name)
             info.put(TaskContract.ACCOUNT_TYPE, account.type)
 
-            logger.log(Level.FINE, "Creating ${provider.name.authority} task list", info)
-            return provider.client.insert(provider.taskListsUri().asSyncAdapter(account), info)
+            val url = TaskLists.getContentUri(providerName.authority).asSyncAdapter(account)
+            logger.log(Level.FINE, "Creating ${providerName.authority} task list", info)
+            return provider.insert(url, info)
                 ?: throw CalendarStorageException("Couldn't create task list (empty result from provider)")
         }
 
@@ -113,7 +114,7 @@ abstract class DmfsTaskList<out T : DmfsTask>(
      * Called when an instance is created from a tasks provider data row, for example
      * using [find].
      *
-     * @param info  values from tasks provider
+     * @param values  values from tasks provider
      */
     @CallSuper
     protected open fun populate(values: ContentValues) {

--- a/lib/src/main/kotlin/at/bitfire/ical4android/DmfsTaskListFactory.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/DmfsTaskListFactory.kt
@@ -5,9 +5,10 @@
 package at.bitfire.ical4android
 
 import android.accounts.Account
+import android.content.ContentProviderClient
 
 interface DmfsTaskListFactory<out T: DmfsTaskList<DmfsTask>> {
 
-    fun newInstance(account: Account, provider: TaskProvider, id: Long): T
+    fun newInstance(account: Account, provider: ContentProviderClient, providerName: TaskProvider.ProviderName, id: Long): T
 
 }


### PR DESCRIPTION
### Purpose
See the issue #161 

### Desc

Take ContentProviderClient instead of TasksProvider in DmfsTaskList:
- find method - have to pass context along, otherwise we need to also change interfaces and factories for DmfsTaskList
- create method
- tests 