### PR TITLE
Fix deprecation of `first`

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidEventTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidEventTest.kt
@@ -2218,12 +2218,12 @@ class AndroidEventTest {
         val params = ParameterList()
         params.add(Language("en"))
         val unknownProperty = XProperty("X-NAME", params, "Custom Value")
-        val result = populateEvent(
+        val (result) = populateEvent(
             true,
             extendedProperties = mapOf(
                 UnknownProperty.CONTENT_ITEM_TYPE to UnknownProperty.toJsonString(unknownProperty)
             )
-        ).unknownProperties.first
+        ).unknownProperties
         assertEquals("X-NAME", result.name)
         assertEquals("en", result.getParameter<Language>(Parameter.LANGUAGE).value)
         assertEquals("Custom Value", result.value)
@@ -2258,8 +2258,8 @@ class AndroidEventTest {
         }).let { event ->
             assertEquals("Recurring non-all-day event with exception", event.summary)
             assertEquals(DtStart("20200706T193000", tzVienna), event.dtStart)
-            assertEquals("FREQ=DAILY;COUNT=10", event.rRules.first.value)
-            val exception = event.exceptions.first!!
+            assertEquals("FREQ=DAILY;COUNT=10", event.rRules.first().value)
+            val exception = event.exceptions.first()
             assertEquals(RecurrenceId("20200708T013000", tzShanghai), exception.recurrenceId)
             assertEquals(DtStart("20200706T203000", tzShanghai), exception.dtStart)
             assertEquals("Event moved to one hour later", exception.summary)
@@ -2286,8 +2286,8 @@ class AndroidEventTest {
         }).let { event ->
             assertEquals("Recurring all-day event with exception", event.summary)
             assertEquals(DtStart(Date("20200706")), event.dtStart)
-            assertEquals("FREQ=WEEKLY;COUNT=3", event.rRules.first.value)
-            val exception = event.exceptions.first!!
+            assertEquals("FREQ=WEEKLY;COUNT=3", event.rRules.first().value)
+            val exception = event.exceptions.first()
             assertEquals(RecurrenceId(Date("20200707")), exception.recurrenceId)
             assertEquals(DtStart("20200706T183000", tzShanghai), exception.dtStart)
             assertEquals("Today not an all-day event", exception.summary)
@@ -2314,8 +2314,8 @@ class AndroidEventTest {
         }).let { event ->
             assertEquals("Recurring all-day event with cancelled exception", event.summary)
             assertEquals(DtStart("20200706T193000", tzVienna), event.dtStart)
-            assertEquals("FREQ=DAILY;COUNT=10", event.rRules.first.value)
-            assertEquals(DateTime("20200708T013000", tzShanghai), event.exDates.first.dates.first())
+            assertEquals("FREQ=DAILY;COUNT=10", event.rRules.first().value)
+            assertEquals(DateTime("20200708T013000", tzShanghai), event.exDates.first().dates.first())
             assertTrue(event.exceptions.isEmpty())
         }
     }

--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/EventTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/EventTest.kt
@@ -92,13 +92,13 @@ class EventTest {
         e = findEvent(events, "multiple-1@ical4android.EventTest")
         assertEquals("Event 1", e.summary)
         assertEquals(1, e.exceptions.size)
-        assertEquals("Event 1 Exception", e.exceptions.first.summary)
+        assertEquals("Event 1 Exception", e.exceptions.first().summary)
 
         e = findEvent(events, "multiple-2@ical4android.EventTest")
         assertEquals("Event 2", e.summary)
         assertEquals(2, e.exceptions.size)
-        assertTrue("Event 2 Updated Exception 1" == e.exceptions.first.summary || "Event 2 Updated Exception 1" == e.exceptions[1].summary)
-        assertTrue("Event 2 Exception 2" == e.exceptions.first.summary || "Event 2 Exception 2" == e.exceptions[1].summary)
+        assertTrue("Event 2 Updated Exception 1" == e.exceptions.first().summary || "Event 2 Updated Exception 1" == e.exceptions[1].summary)
+        assertTrue("Event 2 Exception 2" == e.exceptions.first().summary || "Event 2 Exception 2" == e.exceptions[1].summary)
     }
 
 
@@ -110,9 +110,9 @@ class EventTest {
         assertEquals("Test Description", event.description)
         assertEquals("中华人民共和国", event.location)
         assertEquals(Css3Color.aliceblue, event.color)
-        assertEquals("cyrus@example.com", event.attendees.first.parameters.getParameter<Email>("EMAIL").value)
+        assertEquals("cyrus@example.com", event.attendees.first().parameters.getParameter<Email>("EMAIL").value)
 
-        val unknown = event.unknownProperties.first
+        val (unknown) = event.unknownProperties
         assertEquals("X-UNKNOWN-PROP", unknown.name)
         assertEquals("xxx", unknown.getParameter<Parameter>("param1").value)
         assertEquals("Unknown Value", unknown.value)

--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/Ical4jTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/Ical4jTest.kt
@@ -38,7 +38,7 @@ class Ical4jTest {
                         "END:VCALENDAR"
             )
         ).first()
-        assertEquals("attendee1@example.virtual", e.attendees.first.getParameter<Email>(Parameter.EMAIL).value)
+        assertEquals("attendee1@example.virtual", e.attendees.first().getParameter<Email>(Parameter.EMAIL).value)
     }
 
     @Test

--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/TaskTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/TaskTest.kt
@@ -174,11 +174,11 @@ class TaskTest {
 
         assertArrayEquals(arrayOf("Test","Sample"), t.categories.toArray())
 
-        val sibling = t.relatedTo.first
+        val (sibling) = t.relatedTo
         assertEquals("most-fields2@example.com", sibling.value)
         assertEquals(RelType.SIBLING, (sibling.getParameter(Parameter.RELTYPE) as RelType))
 
-        val unknown = t.unknownProperties.first
+        val (unknown) = t.unknownProperties
         assertEquals("X-UNKNOWN-PROP", unknown.name)
         assertEquals("xxx", unknown.getParameter<Parameter>("param1").value)
         assertEquals("Unknown Value", unknown.value)


### PR DESCRIPTION
Used positional components (`val (first) = list`) when possible. Otherwise using `first` as function as recommended by the warning.