### PR TITLE
AndroidCompatTimeZoneRegistry logs inappropriate warning when constructing Europe/Copenhagen from Europe/Berlin

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistryTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistryTest.kt
@@ -78,6 +78,13 @@ class AndroidCompatTimeZoneRegistryTest {
     }
 
     @Test
+    fun getTimeZone_Copenhagen_NoBerlin() {
+        val tz = registry.getTimeZone("Europe/Copenhagen")!!
+        assertEquals("Europe/Copenhagen", tz.id)
+        assertFalse(tz.vTimeZone.toString().contains("Berlin"))
+    }
+
+    @Test
     fun getTimeZone_NotExisting() {
         assertNull(registry.getTimeZone("Test/NotExisting"))
     }

--- a/lib/src/main/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistry.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistry.kt
@@ -10,6 +10,8 @@ import net.fortuna.ical4j.model.component.VTimeZone
 import net.fortuna.ical4j.model.property.TzId
 import java.time.ZoneId
 import java.util.logging.Logger
+import net.fortuna.ical4j.model.property.TzUrl
+import net.fortuna.ical4j.model.property.XProperty
 
 /**
  * Wrapper around default [TimeZoneRegistry] that uses the Android name if a time zone has a
@@ -67,13 +69,13 @@ class AndroidCompatTimeZoneRegistry(
            but most Android devices don't now Europe/Kyiv yet.
            */
         if (tz.id != androidTzId) {
-            logger.warning("Using Android TZID $androidTzId instead of ical4j ${tz.id}")
+            logger.fine("Using ical4j timezone ${tz.id} data to construct Android timezone $androidTzId")
 
             // create a copy of the VTIMEZONE so that we don't modify the original registry values (which are not immutable)
             val vTimeZone = tz.vTimeZone
             val newVTimeZoneProperties = PropertyList(vTimeZone.properties)
-            newVTimeZoneProperties.removeAll { property ->
-                property is TzId
+            newVTimeZoneProperties.removeAll { prop ->
+                prop is TzId || prop is TzUrl || prop.name == "X-LIC-LOCATION"
             }
             newVTimeZoneProperties += TzId(androidTzId)
             return TimeZone(VTimeZone(

--- a/lib/src/main/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistry.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistry.kt
@@ -69,7 +69,7 @@ class AndroidCompatTimeZoneRegistry(
            but most Android devices don't now Europe/Kyiv yet.
            */
         if (tz.id != androidTzId) {
-            logger.fine("Using ical4j timezone ${tz.id} data to construct Android timezone $androidTzId")
+            logger.info("Using ical4j timezone ${tz.id} data to construct Android timezone $androidTzId")
 
             // create a copy of the VTIMEZONE so that we don't modify the original registry values (which are not immutable)
             val vTimeZone = tz.vTimeZone

--- a/lib/src/main/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistry.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistry.kt
@@ -10,6 +10,9 @@ import net.fortuna.ical4j.model.component.VTimeZone
 import net.fortuna.ical4j.model.property.TzId
 import java.time.ZoneId
 import java.util.logging.Logger
+import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.component.Daylight
+import net.fortuna.ical4j.model.component.Standard
 import net.fortuna.ical4j.model.property.TzUrl
 import net.fortuna.ical4j.model.property.XProperty
 
@@ -73,10 +76,7 @@ class AndroidCompatTimeZoneRegistry(
 
             // create a copy of the VTIMEZONE so that we don't modify the original registry values (which are not immutable)
             val vTimeZone = tz.vTimeZone
-            val newVTimeZoneProperties = PropertyList(vTimeZone.properties)
-            newVTimeZoneProperties.removeAll { prop ->
-                prop is TzId || prop is TzUrl || prop.name == "X-LIC-LOCATION"
-            }
+            val newVTimeZoneProperties = PropertyList<Property>()
             newVTimeZoneProperties += TzId(androidTzId)
             return TimeZone(VTimeZone(
                 newVTimeZoneProperties,

--- a/lib/src/main/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistry.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistry.kt
@@ -69,7 +69,7 @@ class AndroidCompatTimeZoneRegistry(
            but most Android devices don't now Europe/Kyiv yet.
            */
         if (tz.id != androidTzId) {
-            logger.info("Using ical4j timezone ${tz.id} data to construct Android timezone $androidTzId")
+            logger.fine("Using ical4j timezone ${tz.id} data to construct Android timezone $androidTzId")
 
             // create a copy of the VTIMEZONE so that we don't modify the original registry values (which are not immutable)
             val vTimeZone = tz.vTimeZone

--- a/lib/src/main/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistry.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/AndroidCompatTimeZoneRegistry.kt
@@ -1,6 +1,9 @@
 package at.bitfire.ical4android
 
+import java.time.ZoneId
+import java.util.logging.Logger
 import net.fortuna.ical4j.model.DefaultTimeZoneRegistryFactory
+import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.PropertyList
 import net.fortuna.ical4j.model.TimeZone
 import net.fortuna.ical4j.model.TimeZoneRegistry
@@ -8,13 +11,6 @@ import net.fortuna.ical4j.model.TimeZoneRegistryFactory
 import net.fortuna.ical4j.model.TimeZoneRegistryImpl
 import net.fortuna.ical4j.model.component.VTimeZone
 import net.fortuna.ical4j.model.property.TzId
-import java.time.ZoneId
-import java.util.logging.Logger
-import net.fortuna.ical4j.model.Property
-import net.fortuna.ical4j.model.component.Daylight
-import net.fortuna.ical4j.model.component.Standard
-import net.fortuna.ical4j.model.property.TzUrl
-import net.fortuna.ical4j.model.property.XProperty
 
 /**
  * Wrapper around default [TimeZoneRegistry] that uses the Android name if a time zone has a


### PR DESCRIPTION
I've removed the `TZURL` and `X-LIC-LOCATION` properties, and added a test that makes sure there are no references to Berlin when using Copenhagen.

Also changed the log level to fine, and modified the message to be less dramatic.

<details>
<summary>Timezone Definition</summary>

```
BEGIN:VTIMEZONE
LAST-MODIFIED:20240422T053450Z
X-PROLEPTIC-TZNAME:LMT
TZID:Europe/Copenhagen
BEGIN:STANDARD
TZNAME:CET
TZOFFSETFROM:+005328
TZOFFSETTO:+0100
DTSTART:18930401T011444
END:STANDARD
BEGIN:DAYLIGHT
TZNAME:CEST
TZOFFSETFROM:+0100
TZOFFSETTO:+0200
DTSTART:19160501T000000
RDATE:19400401T020000
RDATE:19430329T020000
RDATE:19460414T020000
RDATE:19470406T030000
RDATE:19480418T020000
RDATE:19490410T020000
RDATE:19800406T020000
END:DAYLIGHT
BEGIN:STANDARD
TZNAME:CET
TZOFFSETFROM:+0200
TZOFFSETTO:+0100
DTSTART:19161001T020000
RDATE:19421102T030000
RDATE:19431004T030000
RDATE:19441002T030000
RDATE:19451118T030000
RDATE:19461007T030000
END:STANDARD
BEGIN:DAYLIGHT
TZNAME:CEST
TZOFFSETFROM:+0100
TZOFFSETTO:+0200
DTSTART:19170416T030000
RRULE:FREQ=YEARLY;UNTIL=19180415T010000Z;BYMONTH=4;BYDAY=3MO
END:DAYLIGHT
BEGIN:STANDARD
TZNAME:CET
TZOFFSETFROM:+0200
TZOFFSETTO:+0100
DTSTART:19170917T040000
RRULE:FREQ=YEARLY;UNTIL=19180916T010000Z;BYMONTH=9;BYDAY=3MO
END:STANDARD
BEGIN:DAYLIGHT
TZNAME:CEST
TZOFFSETFROM:+0100
TZOFFSETTO:+0200
DTSTART:19440403T020000
RRULE:FREQ=YEARLY;UNTIL=19450402T010000Z;BYMONTH=4;BYDAY=1MO
END:DAYLIGHT
BEGIN:DAYLIGHT
TZNAME:CEMT
TZOFFSETFROM:+0200
TZOFFSETTO:+0300
DTSTART:19450524T020000
RDATE:19470511T030000
END:DAYLIGHT
BEGIN:DAYLIGHT
TZNAME:CEST
TZOFFSETFROM:+0300
TZOFFSETTO:+0200
DTSTART:19450924T030000
RDATE:19470629T030000
END:DAYLIGHT
BEGIN:STANDARD
TZNAME:CET
TZOFFSETFROM:+0100
TZOFFSETTO:+0100
DTSTART:19460101T000000
RDATE:19800101T000000
END:STANDARD
BEGIN:STANDARD
TZNAME:CET
TZOFFSETFROM:+0200
TZOFFSETTO:+0100
DTSTART:19471005T030000
RRULE:FREQ=YEARLY;UNTIL=19491002T010000Z;BYMONTH=10;BYDAY=1SU
END:STANDARD
BEGIN:STANDARD
TZNAME:CET
TZOFFSETFROM:+0200
TZOFFSETTO:+0100
DTSTART:19800928T030000
RRULE:FREQ=YEARLY;UNTIL=19950924T010000Z;BYMONTH=9;BYDAY=-1SU
END:STANDARD
BEGIN:DAYLIGHT
TZNAME:CEST
TZOFFSETFROM:+0100
TZOFFSETTO:+0200
DTSTART:19810329T020000
RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
END:DAYLIGHT
BEGIN:STANDARD
TZNAME:CET
TZOFFSETFROM:+0200
TZOFFSETTO:+0100
DTSTART:19961027T030000
RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
END:STANDARD
END:VTIMEZONE
```
</details>
