### PR TITLE
AndroidEvent: correctly reset color on `update()` without event color

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidEventTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidEventTest.kt
@@ -581,7 +581,6 @@ class AndroidEventTest {
 
     @Test
     fun testBuildEvent_Color_WhenNotAvailable() {
-        AndroidCalendar.removeColors(provider, testAccount)
         buildEvent(true) {
             color = Css3Color.darkseagreen
         }.let { result ->
@@ -1700,10 +1699,19 @@ class AndroidEventTest {
     }
 
     @Test
-    fun testPopulateEvent_Color() {
+    fun testPopulateEvent_Color_FromIndex() {
         AndroidCalendar.insertColors(provider, testAccount)
         populateEvent(true) {
             put(Events.EVENT_COLOR_KEY, Css3Color.silver.name)
+        }.let { result ->
+            assertEquals(Css3Color.silver, result.color)
+        }
+    }
+
+    @Test
+    fun testPopulateEvent_Color_FromValue() {
+        populateEvent(true) {
+            put(Events.EVENT_COLOR, Css3Color.silver.argb)
         }.let { result ->
             assertEquals(Css3Color.silver, result.color)
         }
@@ -2355,6 +2363,30 @@ class AndroidEventTest {
         } finally {
             updatedEvent.delete()
         }
+    }
+
+    @Test
+    fun testUpdateEvent_ResetColor() {
+        // add event with color
+        val event = Event().apply {
+            uid = "sample1@testAddEvent"
+            dtStart = DtStart(DateTime())
+            color = Css3Color.silver
+        }
+        val uri = TestEvent(calendar, event).add()
+        val id = ContentUris.parseId(uri)
+
+        // verify that it has color
+        val beforeUpdate = calendar.findById(id)
+        assertNotNull(beforeUpdate.event?.color)
+
+        // update: reset color
+        event.color = null
+        beforeUpdate.update(event)
+
+        // verify that it doesn't have color anymore
+        val afterUpdate = calendar.findById(id)
+        assertNull(afterUpdate.event!!.color)
     }
 
     @Test

--- a/lib/src/main/kotlin/at/bitfire/ical4android/AndroidEvent.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/AndroidEvent.kt
@@ -336,13 +336,19 @@ abstract class AndroidEvent(
         event.location = row.getAsString(Events.EVENT_LOCATION)
         event.description = row.getAsString(Events.DESCRIPTION)
 
-        row.getAsString(Events.EVENT_COLOR_KEY)?.let { name ->
-            try {
-                event.color = Css3Color.valueOf(name)
-            } catch (e: IllegalArgumentException) {
-                logger.warning("Ignoring unknown color $name from Calendar Provider")
+        // color can be specified as RGB value and/or as index key (CSS3 color of AndroidCalendar)
+        event.color =
+            row.getAsString(Events.EVENT_COLOR_KEY)?.let { name ->      // try color key first
+                try {
+                    Css3Color.valueOf(name)
+                } catch (_: IllegalArgumentException) {
+                    logger.warning("Ignoring unknown color name \"$name\"")
+                    null
+                }
+            } ?:
+            row.getAsInteger(Events.EVENT_COLOR)?.let { color ->        // otherwise, try to find the color name from the value
+                Css3Color.entries.firstOrNull { it.argb == color }
             }
-        }
 
         // status
         when (row.getAsInteger(Events.STATUS)) {
@@ -928,18 +934,22 @@ abstract class AndroidEvent(
         builder.withValue(Events.TITLE, event.summary)
         builder.withValue(Events.EVENT_LOCATION, event.location)
         builder.withValue(Events.DESCRIPTION, event.description)
-        builder.withValue(Events.EVENT_COLOR_KEY, event.color?.let { color ->
-            val colorName = color.name
+
+        val color = event.color
+        if (color != null) {
             // set event color (if it's available for this account)
             calendar.provider.query(Colors.CONTENT_URI.asSyncAdapter(calendar.account), arrayOf(Colors.COLOR_KEY),
-                    "${Colors.COLOR_KEY}=? AND ${Colors.COLOR_TYPE}=${Colors.TYPE_EVENT}", arrayOf(colorName), null)?.use { cursor ->
+                    "${Colors.COLOR_KEY}=? AND ${Colors.COLOR_TYPE}=${Colors.TYPE_EVENT}", arrayOf(color.name), null)?.use { cursor ->
                 if (cursor.moveToNext())
-                    return@let colorName
+                    builder.withValue(Events.EVENT_COLOR_KEY, color.name)
                 else
-                    logger.fine("Ignoring event color: $colorName (not available for this account)")
+                    logger.fine("Ignoring event color \"${color.name}\" (not available for this account)")
             }
-            null
-        })
+        } else {
+            // reset color index and value
+            builder .withValue(Events.EVENT_COLOR_KEY, null)
+                    .withValue(Events.EVENT_COLOR, null)
+        }
 
         // scheduling
         val groupScheduled = event.attendees.isNotEmpty()


### PR DESCRIPTION
- `update()`: correctly reset color (implemented in `buildEvent`)
- `buildEvent`: set both color value and index to `null` if there's no event color (previously: only index, so value was not reset on update)
- `populateEvent`: set `Event` color from value (if there's a matching CSS3 color) even if no color name is set. We need test for detecting whether a color value is still present in the tests.