### PR TITLE
Events: map <no CLASS> to Android `ACCESS_DEFAULT`

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidEventTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/AndroidEventTest.kt
@@ -745,7 +745,7 @@ class AndroidEventTest {
     fun testBuildEvent_Classification_None() {
         buildEvent(true) {
         }.let { result ->
-            assertEquals(Events.ACCESS_PUBLIC, result.getAsInteger(Events.ACCESS_LEVEL))
+            assertEquals(Events.ACCESS_DEFAULT, result.getAsInteger(Events.ACCESS_LEVEL))
             assertNull(firstUnknownProperty(result))
         }
     }

--- a/lib/src/main/kotlin/at/bitfire/ical4android/AndroidEvent.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/AndroidEvent.kt
@@ -983,7 +983,8 @@ abstract class AndroidEvent(
 
         builder .withValue(Events.AVAILABILITY, if (event.opaque) Events.AVAILABILITY_BUSY else Events.AVAILABILITY_FREE)
                 .withValue(Events.ACCESS_LEVEL, when (event.classification) {
-                    null, Clazz.PUBLIC -> Events.ACCESS_PUBLIC
+                    null -> Events.ACCESS_DEFAULT
+                    Clazz.PUBLIC -> Events.ACCESS_PUBLIC
                     Clazz.CONFIDENTIAL -> Events.ACCESS_CONFIDENTIAL
                     else /* including Events.ACCESS_PRIVATE */ -> Events.ACCESS_PRIVATE
                 })


### PR DESCRIPTION
instead of `ACCESS_PUBLIC`