### PR TITLE
Query recur instance without dtstart

### DIFF
--- a/lib/src/androidTest/kotlin/at/bitfire/ical4android/JtxCollectionTest.kt
+++ b/lib/src/androidTest/kotlin/at/bitfire/ical4android/JtxCollectionTest.kt
@@ -106,6 +106,31 @@ class JtxCollectionTest {
     }
 
     @Test
+    fun queryRecur_test() {
+        val collectionUri = JtxCollection.create(testAccount, client, cv)
+        assertNotNull(collectionUri)
+
+        val collections = JtxCollection.find(testAccount, client, context, TestJtxCollection.Factory, null, null)
+        val item = collections[0].queryRecur("abc1234", "xyz5678")
+        assertNull(item)
+
+        val cv = ContentValues().apply {
+            put(JtxContract.JtxICalObject.UID, "abc1234")
+            put(JtxContract.JtxICalObject.RECURID, "xyz5678")
+            put(JtxContract.JtxICalObject.RECURID_TIMEZONE, "Europe/Vienna")
+            put(JtxContract.JtxICalObject.SUMMARY, "summary")
+            put(JtxContract.JtxICalObject.COMPONENT, JtxContract.JtxICalObject.Component.VJOURNAL.name)
+            put(JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID, collections[0].id)
+        }
+        client.insert(JtxContract.JtxICalObject.CONTENT_URI.asSyncAdapter(testAccount), cv)
+        val contentValues = collections[0].queryRecur("abc1234", "xyz5678")
+
+        assertEquals("abc1234", contentValues?.getAsString(JtxContract.JtxICalObject.UID))
+        assertEquals("xyz5678", contentValues?.getAsString(JtxContract.JtxICalObject.RECURID))
+        assertEquals("Europe/Vienna", contentValues?.getAsString(JtxContract.JtxICalObject.RECURID_TIMEZONE))
+    }
+
+    @Test
     fun getICSForCollection_test() {
         val collectionUri = JtxCollection.create(testAccount, client, cv)
         assertNotNull(collectionUri)

--- a/lib/src/main/kotlin/at/bitfire/ical4android/JtxCollection.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/JtxCollection.kt
@@ -192,7 +192,7 @@ open class JtxCollection<out T: JtxICalObject>(val account: Account,
             arrayOf(uid, recurid),
             null
         ).use { cursor ->
-            logger.fine("queryByUID: found ${cursor?.count} records in ${account.name}")
+            logger.fine("queryRecur: found ${cursor?.count} records in ${account.name}")
             if (cursor?.count != 1)
                 return null
             cursor.moveToFirst()

--- a/lib/src/main/kotlin/at/bitfire/ical4android/JtxCollection.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/JtxCollection.kt
@@ -181,6 +181,7 @@ open class JtxCollection<out T: JtxICalObject>(val account: Account,
 
     /**
      * @param [uid] of the entry that should be retrieved as content values
+     * @param [recurid] of the entry that should be retrieved as content values
      * @return Content Values of the found item with the given UID or null if the result was empty or more than 1
      * The query checks for the [uid] within all collections of this account, not only the current collection.
      */

--- a/lib/src/main/kotlin/at/bitfire/ical4android/JtxCollection.kt
+++ b/lib/src/main/kotlin/at/bitfire/ical4android/JtxCollection.kt
@@ -184,12 +184,12 @@ open class JtxCollection<out T: JtxICalObject>(val account: Account,
      * @return Content Values of the found item with the given UID or null if the result was empty or more than 1
      * The query checks for the [uid] within all collections of this account, not only the current collection.
      */
-    fun queryRecur(uid: String, recurid: String, dtstart: Long): ContentValues? {
+    fun queryRecur(uid: String, recurid: String): ContentValues? {
         client.query(
             JtxContract.JtxICalObject.CONTENT_URI.asSyncAdapter(account),
             null,
-            "${JtxContract.JtxICalObject.UID} = ? AND ${JtxContract.JtxICalObject.RECURID} = ? AND ${JtxContract.JtxICalObject.DTSTART} = ?",
-            arrayOf(uid, recurid, dtstart.toString()),
+            "${JtxContract.JtxICalObject.UID} = ? AND ${JtxContract.JtxICalObject.RECURID} = ?",
+            arrayOf(uid, recurid),
             null
         ).use { cursor ->
             logger.fine("queryByUID: found ${cursor?.count} records in ${account.name}")


### PR DESCRIPTION
Part of https://github.com/bitfireAT/davx5-ose/pull/1336

---

Currently `JtxCollection.queryRecur` can't query instances of recurring VTODOs (got RECURRENCE-ID property) which don't include a DTSTART. This is a valid scenario though and so it should be supported by ical4android. 

VEVENTs, in contrast to VTODOs, do require DTSTART to be present when there is a RECURRENCE-ID, but they _should_ still be able to be uniquely identified with UID and RECURRENCE-ID alone. I am writing _should_, because in theory it could happen that two calendars contain events which both have the same UID and since `queryRecur` does query across all collections, it could happen that we get two VTODOs / VEVENTs back when expecting one only. It seems highly unlikely though.

While using DTSTART as a third query param makes this scenario more unlikely it could still happen and worse: it introduces said problem. 

This PR:
- changes the `queryRecur` method to not include DTSTART
- Adds a simple test
- changes the `queryRecur` log message to include the correct method name


### Further information
In [RFC 5545, Section 3.6.2 – To-Do Component](https://icalendar.org/iCalendar-RFC-5545/3-6-2-to-do-component.html?utm_source=chatgpt.com):​
> "A 'VTODO' calendar component without the 'DTSTART' and 'DUE' (or 'DURATION') properties specifies a to-do that will be associated with each successive calendar date, until it is completed."

From [RFC 5545, Section 3.8.4.7 (UID)](https://icalendar.org/iCalendar-RFC-5545/3-8-4-7-unique-identifier.html):
> "The UID itself MUST be a globally unique identifier."

And:
> "This identifier is created by the calendar system that generates an iCalendar object. [...] The generator of the identifier MUST guarantee that the identifier is unique."

In [RFC 5546, Section 3.6.1](https://datatracker.ietf.org/doc/html/rfc5546#section-3.6.1):
> "The primary key for referencing a particular iCalendar component is the 'UID' property value."